### PR TITLE
Error build on npm failure

### DIFF
--- a/npm_install.sh
+++ b/npm_install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Error out if any command fails
+set -e
+
 cd ../..
 
 NODE_DIR="com.github.harisvsulaiman.pushy.node"


### PR DESCRIPTION
This will cause meson to error, and the build to error, if something goes wrong with the `npm _Install.sh` script.